### PR TITLE
Use the gh CLI to cut releases.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,9 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
       - name: Create a Release
         if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-        uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/*
-          generate_release_notes: true
+        run: >
+          gh release create "$GITHUB_REF_NAME" dist/*
+          --generate-notes
+          --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Replaces `softprops/action-gh-release@v2` with `gh release create`.

```yaml
- name: Create a Release
  if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
  run: >
    gh release create "$GITHUB_REF_NAME" dist/*
    --generate-notes
    --verify-tag
  env:
    GH_TOKEN: ${{ github.token }}
```

`gh` ships on the runner and `contents: write` is already granted to the job,
so nothing new is needed. The mapping is one-for-one — `files: dist/*` becomes
the positional arguments, `generate_release_notes: true` becomes
`--generate-notes`.

The motivation is that `packaging` is the one job holding both
`contents: write` and an OIDC token for PyPI, so it's the job where a
third-party action costs the most and, here, bought the least.

## Two behavioural differences

- **`--verify-tag` is new.** The action would create a tag that didn't exist;
  `gh` now refuses. The job only runs on a tag push, so the tag always exists —
  this just closes off the case where it somehow doesn't.
- **Re-running on an existing release now fails** rather than updating it in
  place. Given a release only happens once per tag, failing loudly seemed
  better than silently rewriting one, but say the word and I'll add
  `|| gh release upload` instead.

## Checked

`actionlint` clean, YAML parses, and the folded scalar resolves to the single
line above. The release path itself can only really be exercised by pushing a
tag, so that part is by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)